### PR TITLE
prevent the use of up/down command when frozen or suspended

### DIFF
--- a/cs_updown.c
+++ b/cs_updown.c
@@ -39,6 +39,7 @@ static void cs_cmd_up(sourceinfo_t *si, int parc, char *parv[])
 	chanuser_t *cu;
 	mychan_t *mc;
 	char *name = parv[0];
+	char *chan = parv[0];
 	int fl;
 
 	if (!name)
@@ -59,6 +60,12 @@ static void cs_cmd_up(sourceinfo_t *si, int parc, char *parv[])
 		command_fail(si, fault_noprivs, "\2%s\2 is closed.", name);
 		return;
 	}
+	
+	if (metadata_find(mc, "private:frozen:freezer"))
+		{
+			command_fail(si, fault_noprivs, _("\2%s\2 is frozen."), chan);
+			return;
+	}
 
 	if (!mc->chan)
 	{
@@ -68,6 +75,12 @@ static void cs_cmd_up(sourceinfo_t *si, int parc, char *parv[])
 
 	if (!si->su)
 		return; // needs to be done over IRC
+	
+	if (chanacs_source_has_flag(mc, si, CA_SUSPENDED))
+        {
+                command_fail(si, fault_noprivs, _("Your access in %s is \2suspended\2."), chan);
+                return;
+        }
 
 	cu = chanuser_find(mc->chan, si->su);
 
@@ -143,6 +156,7 @@ static void cs_cmd_down(sourceinfo_t *si, int parc, char *parv[])
 	chanuser_t *cu;
 	mychan_t *mc;
 	char *name = parv[0];
+	char *chan = parv[0];
 
 	if (!name)
 	{
@@ -162,6 +176,12 @@ static void cs_cmd_down(sourceinfo_t *si, int parc, char *parv[])
 		command_fail(si, fault_noprivs, "\2%s\2 is closed.", name);
 		return;
 	}
+	
+	if (metadata_find(mc, "private:frozen:freezer"))
+	{
+		command_fail(si, fault_noprivs, _("\2%s\2 is frozen."), chan);
+		return;
+	}
 
 	if (!mc->chan)
 	{
@@ -171,6 +191,12 @@ static void cs_cmd_down(sourceinfo_t *si, int parc, char *parv[])
 
 	if (!si->su)
 		return; // needs to be done over IRC
+	
+	if (chanacs_source_has_flag(mc, si, CA_SUSPENDED))
+        {
+               command_fail(si, fault_noprivs, _("Your access in %s is \2suspended\2."), chan);
+               return;
+        }
 
 	cu = chanuser_find(mc->chan, si->su);
 


### PR DESCRIPTION
This prevents people getting channel status when suspended or frozen. 